### PR TITLE
keeping the original factor levels when using formula

### DIFF
--- a/R/compareCluster.R
+++ b/R/compareCluster.R
@@ -33,8 +33,13 @@ compareCluster <- function(geneClusters, fun="enrichGO", data='', ...) {
         if (!is.data.frame(data)) {
             stop ('no data provided with formula for compareCluster')
         } else {
-            geneClusters = dlply(.data=data, all.vars(geneClusters)[2], .fun=function(x) {as.character(x[[all.vars(geneClusters)[1]]])})
+            genes.var       = all.vars(geneClusters)[1]
+            grouping.var    = all.vars(geneClusters)[2]
+            geneClusters = dlply(.data=data, grouping.var, .fun=function(x) {as.character(x[[genes.var]])})
+            clusters.levels = unique(data[[grouping.var]])
         }   
+    } else {
+        clusters.levels = names(geneClusters)
     }
     clProf <- llply(geneClusters,
                     .fun=function(i) {
@@ -46,6 +51,7 @@ compareCluster <- function(geneClusters, fun="enrichGO", data='', ...) {
                     )
     clProf.df <- ldply(clProf, rbind)
     clProf.df <- rename(clProf.df, c(.id="Cluster"))
+    clProf.df$Cluster = factor(clProf.df$Cluster, levels=clusters.levels)
 
     ##colnames(clProf.df)[1] <- "Cluster"
     new("compareClusterResult",
@@ -218,7 +224,7 @@ setMethod("plot", signature(x="compareClusterResult"),
                   gsize <- as.numeric(sub("/\\d+$", "", as.character(result$GeneRatio)))
                   gcsize <- as.numeric(sub("^\\d+/", "", as.character(result$GeneRatio)))
                   result$GeneRatio = gsize/gcsize
-                  result$Cluster <- paste(as.character(result$Cluster),"\n", "(", gcsize, ")", sep="")   # Transform to factor to keep the original order?
+                  result$Cluster <- paste(as.character(result$Cluster),"\n", "(", gcsize, ")", sep="")
               } else {
                   ## nothing
               }


### PR DESCRIPTION
Thank you for adding me as a contributor, that's great!

This commit preserves the original order of the factors in the Cluster column of the compareClusters function. This way it becomes possible to define the order in which Clusters are printed and shown in the plots.

mydf <- data.frame(Entrez=c('1', '100', '1000', '100101467', '100127206', '100128071'), group = c('A', 'A', 'A', 'B', 'B', 'B'))
mydf$group.reverseorder     = factor(mydf$group, levels=c('B', 'A'))
mydf$group.nofactor         = as.character(mydf$group)

The original order of the grouping variable is preserved in the output. When grouping by the "group.reverseorder" variable, the "B" terms are shown first:
> compareCluster(Entrez~group.reverseorder, data=mydf, fun='groupGO')  %>% summary %>% head
  Cluster         ID          Description Count GeneRatio    geneID
  1       B GO:0016020             membrane     1       1/3 100127206
  2       B GO:0005576 extracellular region     0       0/3
  3       B GO:0005581      collagen trimer     0       0/3
  4       B GO:0005623                 cell     1       1/3 100101467
  5       B GO:0009295             nucleoid     0       0/3
  6       B GO:0019012               virion     0       0/3

If the original grouping column was not a factor, we use the original order, and no errors are shown
> compareCluster(Entrez~group.nofactor, data=mydf, fun='groupGO')  %>% summary %>% head
  Cluster         ID          Description Count GeneRatio     geneID
  1       A GO:0016020             membrane     2       2/5   100/1000
  2       A GO:0005576 extracellular region     3       3/5 1/100/1000
  3       A GO:0005581      collagen trimer     0       0/5
  4       A GO:0005623                 cell     2       2/5   100/1000
  5       A GO:0009295             nucleoid     0       0/5
  6       A GO:0019012               virion     0       0/5

The list interface still works correctly:
> compareCluster(list(B=as.character(subset(mydf, group=='B')$Entrez), A=as.character(subset(mydf, group=='A')$Entrez)), data='', fun='groupGO')  %>% summary %>% head
  Cluster         ID          Description Count GeneRatio    geneID
  1       B GO:0016020             membrane     1       1/3 100127206
  2       B GO:0005576 extracellular region     0       0/3
  3       B GO:0005581      collagen trimer     0       0/3
  4       B GO:0005623                 cell     1       1/3 100101467
  5       B GO:0009295             nucleoid     0       0/3
  6       B GO:0019012               virion     0       0/3