### PR TITLE
added an includeAll option in plot(compareCluster)

### DIFF
--- a/R/compareCluster.R
+++ b/R/compareCluster.R
@@ -157,7 +157,9 @@ setMethod("plot", signature(x="compareClusterResult"),
                    font.size=12,
                    showCategory=5,
                    by="geneRatio",
-                   colorBy="p.adjust") {
+                   colorBy="p.adjust",
+                   includeAll=F
+                   ) {
 
               clProf.df <- summary(x)
 
@@ -178,6 +180,10 @@ setMethod("plot", signature(x="compareClusterResult"),
                                   },
                                   N=showCategory
                                   )
+
+              }
+              if (includeAll == T) {
+                  result = subset(clProf.df, ID %in% result$ID)
               }
 
               ## remove zero count


### PR DESCRIPTION
This should fix issue #9 

The new code adds an option called includeAll to plot for compareCluster. I am not sure if this is the most appropriate name for the option, but I could not think of anything better. Please feel free to change it if necessary.