### PR TITLE
Fix documentation of "ont" argument for GO analyses

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ BugReports: https://github.com/GuangchuangYu/clusterProfiler/issues
 Packaged: NA
 biocViews: Annotation, Clustering, GeneSetEnrichment, GO, KEGG,
     MultipleComparison, Pathways, Reactome, Visualization
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1

--- a/R/enrichGO.R
+++ b/R/enrichGO.R
@@ -6,7 +6,7 @@
 ##' @param gene a vector of entrez gene id.
 ##' @param OrgDb OrgDb
 ##' @param keyType keytype of input gene
-##' @param ont One of "MF", "BP", and "CC" subontologies.
+##' @param ont One of "BP", "MF", and "CC" subontologies, or "ALL" for all three.
 ##' @param pvalueCutoff Cutoff value of pvalue.
 ##' @param pAdjustMethod one of "holm", "hochberg", "hommel", "bonferroni", "BH", "BY", "fdr", "none"
 ##' @param universe background genes
@@ -42,7 +42,7 @@ enrichGO <- function(gene,
                      readable=FALSE, pool=FALSE) {
 
     ont %<>% toupper
-    ont <- match.arg(ont, c("BP", "CC", "MF", "ALL"))
+    ont <- match.arg(ont, c("BP", "MF", "CC", "ALL"))
     GO_DATA <- get_GO_data(OrgDb, ont, keyType)
 
     if (missing(universe))

--- a/R/gseAnalyzer.R
+++ b/R/gseAnalyzer.R
@@ -3,7 +3,8 @@
 ##'
 ##' @title gseGO
 ##' @param geneList order ranked geneList
-##' @param ont one of "BP", "MF", "CC" or "GO"
+##' @param ont one of "BP", "MF", and "CC" subontologies, or "ALL" for all three.
+##' @param ont one of "BP", "MF", and "CC" subontologies, or "ALL" for all three.
 ##' @param OrgDb OrgDb
 ##' @param keyType keytype of gene
 ##' @param exponent weight of each step
@@ -34,7 +35,7 @@ gseGO <- function(geneList,
                   by = 'fgsea') {
 
     ont %<>% toupper
-    ont <- match.arg(ont, c("BP", "CC", "MF", "ALL"))
+    ont <- match.arg(ont, c("BP", "MF", "CC", "ALL"))
 
     GO_DATA <- get_GO_data(OrgDb, ont, keyType)
 

--- a/man/enrichGO.Rd
+++ b/man/enrichGO.Rd
@@ -18,7 +18,7 @@ enrichGO(gene, OrgDb, keyType = "ENTREZID", ont = "MF",
 
 \item{keyType}{keytype of input gene}
 
-\item{ont}{One of "MF", "BP", and "CC" subontologies.}
+\item{ont}{One of "BP", "MF", and "CC" subontologies, or "ALL" for all three.}
 
 \item{pvalueCutoff}{Cutoff value of pvalue.}
 

--- a/man/gseGO.Rd
+++ b/man/gseGO.Rd
@@ -12,7 +12,7 @@ gseGO(geneList, ont = "BP", OrgDb, keyType = "ENTREZID",
 \arguments{
 \item{geneList}{order ranked geneList}
 
-\item{ont}{one of "BP", "MF", "CC" or "GO"}
+\item{ont}{one of "BP", "MF", and "CC" subontologies, or "ALL" for all three.}
 
 \item{OrgDb}{OrgDb}
 
@@ -35,6 +35,8 @@ gseGO(geneList, ont = "BP", OrgDb, keyType = "ENTREZID",
 \item{seed}{logical}
 
 \item{by}{one of 'fgsea' or 'DOSE'}
+
+\item{ont}{one of "BP", "MF", and "CC" subontologies, or "ALL" for all three.}
 }
 \value{
 gseaResult object

--- a/man/simplify-methods.Rd
+++ b/man/simplify-methods.Rd
@@ -53,7 +53,7 @@ updated compareClusterResult object
 \description{
 simplify output from enrichGO by removing redundancy of enriched GO terms
 
-simplify output from enrichGO by removing redundancy of enriched GO terms
+simplify output from gseGO by removing redundancy of enriched GO terms
 
 simplify output from compareCluster by removing redundancy of enriched GO terms
 }


### PR DESCRIPTION
Hi,
Thanks for the extremely useful package!
Please find a couple of fixes addressing mismatches between the documentation and the code.
Namely, the option `"ALL"` is the keyword that allows the combined analysis of all three namespaces in the Gene Ontology.
It was documented as `"GO"` in `gseAnalyzer.R` and not documented yet in `enrichGO.R`

Best wishes,
Kevin 